### PR TITLE
Finsihed up edit functionality

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -21,55 +21,29 @@
       "name": "Spaghetti",
       "userId": 3,
       "id": 1
-    },
-    {
-      "name": "Hot Dogs",
-      "userId": 3,
-      "id": 2
     }
   ],
   "directions": [
     {
-      "direction": "Boil Noodles",
+      "direction": "Boil lots of Water",
       "recipeId": "1",
       "id": 1
-    },
-    {
-      "direction": "Boil Water",
-      "recipeId": "2",
-      "id": 2
-    },
-    {
-      "direction": "Dey done when they float",
-      "recipeId": "2",
-      "id": 3
     }
   ],
   "ingredients": [
     {
-      "ingredient": "Meat",
-      "recipeId": "1",
+      "ingredient": "2 lbs of hamburger",
       "id": 1
     },
     {
-      "ingredient": "Hot Dogs",
-      "recipeId": "2",
+      "ingredient": "Quit cooking",
+      "recipeId": "1",
       "id": 2
     },
     {
-      "ingredient": "Hot Dogs",
-      "recipeId": "2",
+      "ingredient": "The will to quit",
+      "recipeId": "1",
       "id": 3
-    },
-    {
-      "ingredient": "Buns",
-      "recipeId": "2",
-      "id": 4
-    },
-    {
-      "ingredient": "Mustard",
-      "recipeId": "2",
-      "id": 5
     }
   ]
 }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -55,6 +55,16 @@ class ApplicationViews extends Component {
         })
       );
 
+      updateDirections = editedDirectionObject => {
+        return directionAPIManager.put(editedDirectionObject)
+          .then(() => directionAPIManager.getAllDirections())
+          .then(directions => {
+            this.setState({
+              directions: directions
+            });
+          });
+      };
+
   addIngredient = ingredientObject =>
     ingredientAPIManager.postIngredient(ingredientObject)
       .then(() => ingredientAPIManager.getAllIngredients())
@@ -63,6 +73,17 @@ class ApplicationViews extends Component {
           ingredients: ingredients
         })
       );
+
+
+      updateIngredients = editedIngredientObject => {
+        return ingredientAPIManager.put(editedIngredientObject)
+          .then(() => ingredientAPIManager.getAllIngredients())
+          .then(ingredients => {
+            this.setState({
+              ingredients: ingredients
+            });
+          });
+      };
 
   returnToLibrary = () => {
     console.log("we're inside return to library!")
@@ -129,6 +150,8 @@ class ApplicationViews extends Component {
                 ingredients={this.state.ingredients}
                 directions={this.state.directions}
                 deleteRecipe={this.deleteRecipe}
+                updateIngredients={this.updateIngredients}
+                updateDirections={this.updateDirections}
               />
             );
           }}

--- a/src/components/RecipeLibrary/RecipeDetails.js
+++ b/src/components/RecipeLibrary/RecipeDetails.js
@@ -3,10 +3,63 @@ import React, { Component } from "react";
 
 
 export default class RecipeDetail extends Component {
-  render() {
+
+  state = {
+    userId: "",
+    userEditedDirection: "",
+    IngredientToEdit: {},
+    DirectionToEdit: {},
+    userEditedIngredient: ""
+};
+
+editIngredient = evt => {
+  evt.preventDefault();
+  const editedIngredient = {
+      ingredient: this.state.userEditedIngredient,
+      recipeId: this.state.IngredientToEdit.recipeId,
+      id: this.state.IngredientToEdit.id
+  };
+  this.props.updateIngredients(editedIngredient)
+      .then(this.setState({ IngredientToEdit: "" }))
+      .then()
+
+}
+
+generateIngredientForm = (singleIngredient) => {
+  this.setState({ IngredientToEdit: singleIngredient })
+  };
+
+editDirection = evt => {
+    evt.preventDefault();
+    const editedDirection = {
+        direction: this.state.userEditedDirection,
+        recipeId: this.state.DirectionToEdit.recipeId,
+        id: this.state.DirectionToEdit.id
+    };
+    this.props.updateDirections(editedDirection)
+        .then(this.setState({ DirectionToEdit: "" }))
+        .then()
+
+  }
+
+  generateDirectionForm = (singleDirection) => {
+    this.setState({ DirectionToEdit: singleDirection })
+    };
+
+handleFieldChange = evt => {
+    const stateToChange = {};
+    stateToChange[evt.target.id] = evt.target.value;
+    this.setState(stateToChange);
+};
+
+render() {
+
+
+
+
     /*
-            Using the route parameter, find the animal that the
-            user clicked on by looking at the `this.props.animals`
+            Using the route parameter, find the recipe that the
+            user clicked on by looking at the `this.props.recipes`
             collection that was passed down from ApplicationViews
         */
     const recipe =
@@ -25,20 +78,63 @@ export default class RecipeDetail extends Component {
               <ul>
                 {this.props.ingredients.map(singleIngredient =>{
                   if (singleIngredient.recipeId === this.props.match.params.recipeId) {
-                    return <li className={singleIngredient.id} key={singleIngredient.id}>{singleIngredient.ingredient}</li>
-                  }
+                    if (singleIngredient.id === this.state.IngredientToEdit.id) {
+                      return <div key={this.state.IngredientToEdit.id}><input
+                          type="text"
+                          required
+                          className="form-control"
+                          onChange={this.handleFieldChange}
+                          // This is creating an object in state,
+                          id="userEditedIngredient"
+                          placeholder={this.state.IngredientToEdit.ingredient}
+                          // value={this.state.messageToEdit.message}
+                      />
+                          <button
+                              type="submit"
+                              onClick={this.editIngredient}
+                              className="btn btn-primary"
+                          >Submit New Edit</button></div>
+                    } else {
+                    return <li className={singleIngredient.id} key={singleIngredient.id}>{singleIngredient.ingredient}
+                    <button
+                    type="submit"
+                    onClick={() => this.generateIngredientForm(singleIngredient)}
+                    className="btn btn-primary">
+                    Edit</button></li>
+                  }}
                   else {
                     return null
                   }
                   })}
 
               </ul>
-              <h5 className="card-title">Ingredients Needed</h5>
+{/* /////////////////////////Directions List///////////////////////// */}
+
+              <h5 className="card-title">Directions</h5>
               <ol>
                 {this.props.directions.map(singleDirection =>{
                   if (singleDirection.recipeId === this.props.match.params.recipeId) {
-                    return <li className={singleDirection.id} key={singleDirection.id}>{singleDirection.direction}</li>
-                  }
+                    if (singleDirection.id === this.state.DirectionToEdit.id) {return <div key={this.state.DirectionToEdit.id}><input
+                    type="text"
+                    required
+                    className="form-control"
+                    onChange={this.handleFieldChange}
+                    // This is creating an object in state,
+                    id="userEditedDirection"
+                    placeholder={this.state.DirectionToEdit.direction}
+                    // value={this.state.messageToEdit.message}
+                />
+                    <button
+                        type="submit"
+                        onClick={this.editDirection}
+                        className="btn btn-primary"
+                    >Submit New Edit</button></div>} else {
+                    return <li className={singleDirection.id} key={singleDirection.id}>{singleDirection.direction}<button
+                    type="submit"
+                    onClick={() => this.generateDirectionForm(singleDirection)}
+                    className="btn btn-primary">
+                    Edit</button></li>
+                  }}
                   else {
                     return null
                   }


### PR DESCRIPTION
Able to edit previously entered ingredients on recipe details page.
-Click on directions and ingredients link on a recipe card.
-Should see clickable edit buttons next to each ingredient and direction.
-When you click on the button it should insert an input field with old text.
-Enter in new text and click submit button.
-Should refresh with new ingredient/direction