### PR TITLE
Moved edit functionality to details form page instead of recipe details

### DIFF
--- a/api/database.json
+++ b/api/database.json
@@ -33,43 +33,53 @@
       "id": 8
     },
     {
-      "name": "Meat Loaf",
+      "name": "Chicken Noodle Soup",
       "userId": 3,
       "id": 9
+    },
+    {
+      "name": "Noodles",
+      "userId": 3,
+      "id": 10
+    },
+    {
+      "name": "Fried Chicken",
+      "userId": 3,
+      "id": 11
     }
   ],
   "directions": [
     {
-      "direction": "Grill",
+      "direction": "Boil a whole lot of water",
       "recipeId": "9",
       "id": 1
+    },
+    {
+      "direction": "Fry it",
+      "recipeId": "11",
+      "id": 2
     }
   ],
   "ingredients": [
     {
-      "ingredient": "1 cup of angel hair pasta",
+      "ingredient": "2 lbs of hamburger",
       "recipeId": "9",
       "id": 1
     },
     {
-      "ingredient": "Burger",
+      "ingredient": "2 slices of Chicken",
       "recipeId": "9",
       "id": 2
     },
     {
-      "ingredient": "2 slices of Chicken",
+      "ingredient": "Burger",
       "recipeId": "9",
       "id": 3
     },
     {
-      "ingredient": "2 slices of Chicken",
-      "recipeId": "9",
+      "ingredient": "Chicken",
+      "recipeId": "11",
       "id": 4
-    },
-    {
-      "ingredient": "2 slices of Chicken",
-      "recipeId": "9",
-      "id": 5
     }
   ]
 }

--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -88,10 +88,8 @@ class ApplicationViews extends Component {
 
 
   returnToLibrary = () => {
-    console.log("we're inside return to library!")
     return recipeAPIManager.getAllRecipes()
       .then(recipes => {
-        console.log("we're setting state", recipes)
         this.setState({ recipes: recipes })
       })
 
@@ -177,6 +175,8 @@ class ApplicationViews extends Component {
                 addIngredient={this.addIngredient}
                 returnToLibrary={this.returnToLibrary}
                 deleteRecipe={this.deleteRecipe}
+                updateIngredients={this.updateIngredients}
+                updateDirections={this.updateDirections}
               />;
             } else {
               Auth0Client.signIn();

--- a/src/components/RecipeLibrary/RecipeDetails.js
+++ b/src/components/RecipeLibrary/RecipeDetails.js
@@ -80,30 +80,9 @@ render() {
               <ul>
                 {this.props.ingredients.map(singleIngredient =>{
                   if (singleIngredient.recipeId === currentRecipeId) {
-                    if (singleIngredient.id === this.state.IngredientToEdit.id) {
-                      return <div key={this.state.IngredientToEdit.id}><input
-                          type="text"
-                          required
-                          className="form-control"
-                          onChange={this.handleFieldChange}
-                          // This is creating an object in state,
-                          id="userEditedIngredient"
-                          placeholder={this.state.IngredientToEdit.ingredient}
-                          // value={this.state.messageToEdit.message}
-                      />
-                          <button
-                              type="submit"
-                              onClick={this.editIngredient}
-                              className="btn btn-primary"
-                          >Submit New Edit</button></div>
-                    } else {
                     return <li className={singleIngredient.id} key={singleIngredient.id}>{singleIngredient.ingredient}
-                    <button
-                    type="submit"
-                    onClick={() => this.generateIngredientForm(singleIngredient)}
-                    className="btn btn-primary">
-                    Edit</button></li>
-                  }}
+                    </li>
+                  }
                   else {
                     return null
                   }
@@ -116,27 +95,8 @@ render() {
               <ol>
                 {this.props.directions.map(singleDirection =>{
                   if (singleDirection.recipeId === currentRecipeId) {
-                    if (singleDirection.id === this.state.DirectionToEdit.id) {return <div key={this.state.DirectionToEdit.id}><input
-                    type="text"
-                    required
-                    className="form-control"
-                    onChange={this.handleFieldChange}
-                    // This is creating an object in state,
-                    id="userEditedDirection"
-                    placeholder={this.state.DirectionToEdit.direction}
-                    // value={this.state.messageToEdit.message}
-                />
-                    <button
-                        type="submit"
-                        onClick={this.editDirection}
-                        className="btn btn-primary"
-                    >Submit New Edit</button></div>} else {
-                    return <li className={singleDirection.id} key={singleDirection.id}>{singleDirection.direction}<button
-                    type="submit"
-                    onClick={() => this.generateDirectionForm(singleDirection)}
-                    className="btn btn-primary">
-                    Edit</button></li>
-                  }}
+                    return <li className={singleDirection.id} key={singleDirection.id}>{singleDirection.direction}</li>
+                  }
                   else {
                     return null
                   }

--- a/src/components/RecipeLibrary/RecipeDetailsForm.js
+++ b/src/components/RecipeLibrary/RecipeDetailsForm.js
@@ -10,7 +10,12 @@ export default class RecipeDetailsForm extends Component {
         recipeId: "",
         ingredients: "",
         directions: "",
-        recipe: ""
+        recipe: "",
+        userId: "",
+        userEditedDirection: "",
+        IngredientToEdit: {},
+        DirectionToEdit: {},
+        userEditedIngredient: ""
     };
 
     handleFieldChange = evt => {
@@ -50,6 +55,40 @@ export default class RecipeDetailsForm extends Component {
         }
     };
 
+    editIngredient = evt => {
+        evt.preventDefault();
+        const editedIngredient = {
+            ingredient: this.state.userEditedIngredient,
+            recipeId: this.state.IngredientToEdit.recipeId,
+            id: this.state.IngredientToEdit.id
+        };
+        this.props.updateIngredients(editedIngredient)
+            .then( () => this.setState({ IngredientToEdit: "" }))
+            .then()
+
+      };
+
+      generateIngredientForm = (singleIngredient) => {
+        this.setState({ IngredientToEdit: singleIngredient })
+        };
+
+      editDirection = evt => {
+          evt.preventDefault();
+          const editedDirection = {
+              direction: this.state.userEditedDirection,
+              recipeId: this.state.DirectionToEdit.recipeId,
+              id: this.state.DirectionToEdit.id
+          };
+          this.props.updateDirections(editedDirection)
+              .then( () => this.setState({ DirectionToEdit: "" }))
+              .then()
+
+        }
+
+        generateDirectionForm = (singleDirection) => {
+          this.setState({ DirectionToEdit: singleDirection })
+          };
+
     refresh = evt => {
         evt.preventDefault();
         this.props.returnToLibrary();
@@ -75,7 +114,31 @@ export default class RecipeDetailsForm extends Component {
                         <ul className="IngredientList">
                             {this.props.ingredients.map(singleIngredient => {
                                 if (singleIngredient.recipeId === this.props.match.params.recipeId){
-                                return <p className={singleIngredient.id} key={singleIngredient.id}>{singleIngredient.ingredient}</p>
+                                    if (singleIngredient.id === this.state.IngredientToEdit.id) {
+                                        return <div key={this.state.IngredientToEdit.id}><input
+                                            type="text"
+                                            required
+                                            className="form-control"
+                                            onChange={this.handleFieldChange}
+                                            // This is creating an object in state,
+                                            id="userEditedIngredient"
+                                            placeholder={this.state.IngredientToEdit.ingredient}
+                                            // value={this.state.messageToEdit.message}
+                                        />
+                                            <button
+                                                type="submit"
+                                                onClick={this.editIngredient}
+                                                className="btn btn-primary"
+                                            >Submit New Edit</button></div>
+                                      } else {
+                                      return <p className={singleIngredient.id} key={singleIngredient.id}>{singleIngredient.ingredient}
+                                      <button
+                                      type="submit"
+                                      onClick={() => this.generateIngredientForm(singleIngredient)}
+                                      className="btn btn-primary">
+                                      Edit</button></p>
+                                    }
+
                             } else {
                                 return null
                             }
@@ -101,8 +164,27 @@ export default class RecipeDetailsForm extends Component {
                         <label htmlFor="direction">Directions</label>
                         <ul className="DirectionsList">
                             {this.props.directions.map(singleDirection => {
-                                if (singleDirection.recipeId === this.props.match.params.recipeId){
-                                return <p className={singleDirection.id} key={singleDirection.id}>{singleDirection.direction}</p>
+                                if (singleDirection.recipeId === this.props.match.params.recipeId){if (singleDirection.id === this.state.DirectionToEdit.id) {return <div key={this.state.DirectionToEdit.id}><input
+                                type="text"
+                                required
+                                className="form-control"
+                                onChange={this.handleFieldChange}
+                                // This is creating an object in state,
+                                id="userEditedDirection"
+                                placeholder={this.state.DirectionToEdit.direction}
+                                // value={this.state.messageToEdit.message}
+                            />
+                                <button
+                                    type="submit"
+                                    onClick={this.editDirection}
+                                    className="btn btn-primary"
+                                >Submit New Edit</button></div>} else {
+                                return <li className={singleDirection.id} key={singleDirection.id}>{singleDirection.direction}<button
+                                type="submit"
+                                onClick={() => this.generateDirectionForm(singleDirection)}
+                                className="btn btn-primary">
+                                Edit</button></li>
+                              }
                             }
                             else {
                                 return null


### PR DESCRIPTION
Edit functionality should be moved to recipe details form page instead of the recipe details viewing page. 
   -If you go to recipe details of a made recipe, you will now see a button that says "edit ingredients or directions".
  -Button should take you back to the page where you first entered the ingredients and directions for the recipe.
-You should see an edit button beside each recipe and direction.
-Clicking the button will allow you to do in-line editing to the selected ingredients or direction.
